### PR TITLE
Fixed sparsity bug

### DIFF
--- a/pyswallow/handlers/archive.py
+++ b/pyswallow/handlers/archive.py
@@ -42,8 +42,8 @@ class Archive:
             _population[-1].sparsity = float('inf')
 
             for i in range(1, len(_population) - 1):
-                _sparse = (_population[i - 1].fitness[obj]
-                           - _population[i + 1].fitness[obj])
+                _sparse = (_population[i + 1].fitness[obj]
+                           - _population[i - 1].fitness[obj])
 
                 _population[i].sparsity += _sparse
 

--- a/tests/handlers/test_archive.py
+++ b/tests/handlers/test_archive.py
@@ -38,7 +38,7 @@ class TestArchive:
             if idx == 0 or idx == 29:
                 assert swallow.sparsity == float('inf')
             else:
-                assert swallow.sparsity == -4
+                assert swallow.sparsity == 4
 
     @pytest.mark.parametrize('n_limit', [15,  30, 45])
     def test_sparsity_limit(self, pop_archive, n_limit):
@@ -57,4 +57,4 @@ class TestArchive:
         assert isinstance(leader, ps.MOSwallow)
 
         if method == 1:
-            assert leader.sparsity == -4
+            assert leader.sparsity == 4


### PR DESCRIPTION
Previously the calculation for the sparsity was inverted and this was pushing the optimisation away from the sparser regions. This fix ensures that the sparsity is calculated correctly.

Resolves: #53