### PR TITLE
Fixed Pool/Pickle Bug

### DIFF
--- a/pyswallow/mp/mp_swarm.py
+++ b/pyswallow/mp/mp_swarm.py
@@ -96,3 +96,10 @@ class MPSwarm(Swarm):
             self.iteration += 1
 
         self.rep.log('Optimisation complete...')
+
+    def __getstate__(self) -> dict:
+        return {k: self.__dict__[k] for k in self.__dict__.keys() - {'pool'}}
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self.pool = mp.Pool(processes=self.cores)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='PySwallow',
-    version='1.1.2',
+    version='1.1.3',
     description='A Python Particle Swarm Optimisation Library.',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Added the `__getstate()__` / `__setstate()__` methods to ensure that the `MPSwarm` object can be pickled appropriately.

Resolves: #96