### PR TITLE
Removed redundant call to evaluate_fitness

### DIFF
--- a/pyswallow/mp/mp_swarm.py
+++ b/pyswallow/mp/mp_swarm.py
@@ -64,7 +64,6 @@ class MPSwarm(Swarm):
         self.population = self.pool.map(fn, self.population)
 
         for swallow in self.population:
-            self.evaluate_fitness(swallow, fn)
 
             if self.constraints_manager.violates_position(swallow):
                 continue


### PR DESCRIPTION
Removed the redundant call to `self.evaluate_fitness(swallow, fn)` - this was causing some issues in the optimiser as the `np.ndarray` used was no compatible with the user provided function.

Resolves: #105